### PR TITLE
(build): add maven central release plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: scala
+sbt_args: "-J-Xmx2G"
+
+script:
+  - sbt clean scripted

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019 sbt-paradox-diagrams contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,19 @@
 
 A simple paradox plugin, which will draw diagrams from formal definitions.
 
+## Supported Diagram Types
+ - Sequence Diagrams (via https://bramp.github.io/js-sequence-diagrams)
+ - FlowCharts (via http://flowchart.js.org)
+ - Gantt and others (via https://mermaidjs.github.io)
 
-Used libs:
- - https://bramp.github.io/js-sequence-diagrams/
- - http://flowchart.js.org/
- - https://mermaidjs.github.io/
+## Setup
+
+Add the following lines to your `project/plugins.sbt`:
+```
+addSbtPlugin("com.wanari" % "sbt-paradox-diagrams" % "<current-version>")
+```
  
- 
-Example:
+## Example
 ````
 @@@ seqence-diagram
 ```raw
@@ -20,17 +25,5 @@ Andrew->>China: I am good thanks!
 ```
 @@@ 
 ````
-will render the first example from the js-sequence website. 
-Also `flowchart-diagram` and `mermaid-diagram` works. 
-For more information visit the listed sites.
 
-Install (to the `project/plugins.sbt`):
-```
-resolvers += "jitpack" at "https://jitpack.io"
-addSbtPlugin("com.github.TeamWanari" % "sbt-paradox-diagrams" % "-SNAPSHOT")
-```
-
- 
-TODO:
- - add dot and railroad, idea from: https://github.com/francoislaberge/diagrams
- - release on maven
+see the [docs](docs) for more examples.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ addSbtPlugin("com.wanari" % "sbt-paradox-diagrams" % "<current-version>")
  
 ## Example
 ````
-@@@ seqence-diagram
+@@@ sequence-diagram
 ```raw
 Andrew->China: Says Hello
 Note right of China: China thinks about it

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,49 @@
+## Release to Maven Central
+
+### Requirements
+
+You created the JIRA and Nexus user and the ticket for your group id
+as explained in https://central.sonatype.org/pages/ossrh-guide.html
+
+Add the credentials for the Sonatype plugin:
+
+```
+$HOME/.sbt/(sbt-version 0.13 or 1.0)/sonatype.sbt
+```
+
+should contain
+
+```
+credentials += Credentials("Sonatype Nexus Repository Manager",
+        "oss.sonatype.org",
+        "(Sonatype user name)",
+        "(Sonatype password)")
+```
+
+Make sure you pushed everything to the remote before releasing.
+
+### Run
+Execute
+
+    sbt "release"
+
+Which will:
+ 1. Compare the local git status with the remote (should be same)
+ 1. Compile
+ 1. Test
+ 1. Publish to Central
+ 1. Close the release in the Sonatype OSS Nexus
+ 1. Create a git tag
+ 1. Bump up the version with a commit
+ 1. Push the new master to the remote
+
+The release might enter a loop under certain circumstances (in cross-release at least). Just exist after the push.
+
+Update Docs
+===========
+
+```
+git checkout v<released_version>
+sbt ghpagesPushSite
+```
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,52 @@
+import sbt.url
+import sbtrelease.ReleaseStateTransformations._
+
+enablePlugins(SbtPlugin)
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.6.5")
+
 name := "sbt-paradox-diagrams"
 organization := "com.wanari"
 organizationName := "Wanari Ltd."
 
-version := "0.1-SNAPSHOT"
-
-scalaVersion := "2.12.8"
-
-enablePlugins(SbtPlugin)
-
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.6.5")
-
-licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
+scalaVersion := "2.12.10"
 
 scalafmtOnCompile := true
+
+sbtPlugin := true
+
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
+
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  publishArtifacts,
+  setNextVersion,
+  commitNextVersion,
+  releaseStepCommandAndRemaining("sonatypeReleaseAll"),
+  pushChanges
+)
+
+publishTo := Some(
+  if (isSnapshot.value)
+    Opts.resolver.sonatypeSnapshots
+  else
+    Opts.resolver.sonatypeStaging
+)
+
+publishMavenStyle := true
+licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+homepage := Some(url("https://github.com/TeamWanari/sbt-paradox-diagrams"))
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/TeamWanari/sbt-paradox-diagrams"),
+    "scm:git@github.com:TeamWanari/sbt-paradox-diagrams.git"
+  )
+)
 
 publishM2 := {
   publishM2.value
@@ -21,11 +55,17 @@ publishM2 := {
   d.renameTo(file(sys.env("HOME")) / ".m2/repository/com/wanari/sbt-paradox-diagrams")
 }
 
-sbtPlugin := true
-publishMavenStyle := true
-
 import scala.collection.JavaConverters._
 scriptedLaunchOpts += ("-Dproject.version=" + version.value)
 scriptedLaunchOpts ++= java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.filter(
   a => Seq("-Xmx", "-Xms", "-XX", "-Dfile").exists(a.startsWith)
 )
+
+lazy val debugScripted = if (sys.env.getOrElse("DEBUG_SCRIPTED", "false").toBoolean) {
+  "y"
+} else {
+  "n"
+}
+
+scriptedLaunchOpts += (s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=${debugScripted},address=0")
+scriptedBufferLog := false

--- a/docs.sbt
+++ b/docs.sbt
@@ -1,0 +1,22 @@
+enablePlugins(ParadoxMaterialThemePlugin, ParadoxSitePlugin, GhpagesPlugin)
+
+sourceDirectory in Paradox := baseDirectory.value / "docs"
+
+ParadoxMaterialThemePlugin.paradoxMaterialThemeSettings(Paradox)
+
+paradoxProperties += ("version" -> version.value)
+
+mappings in makeSite ++= Seq(
+  file("LICENSE") -> "LICENSE"
+)
+
+paradoxMaterialTheme in Paradox := {
+  ParadoxMaterialTheme()
+    .withColor("light-green", "light-green")
+    .withCopyright("© sbt-paradox-diagrams contributors")
+    .withRepository(uri("https://github.com/TeamWanari/sbt-paradox-diagrams"))
+    .withFont("Source Sans Pro", "Iosevka")
+    .withLogoIcon("multiline_chart")
+}
+
+git.remoteRepo := "git@github.com:TeamWanari/sbt-paradox-diagrams.git"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,20 @@
+## Examples
+
+@@include[Sequence Diagram](../snippets/sequence.md)
+
+is created via
+
+@@snip[Sequence Source](../snippets/sequence.md){#sequence}
+
+
+@@include[Flow Diagram](../snippets/flow.md)
+
+is created via
+
+@@snip[Flow Source](../snippets/flow.md){#flow}
+
+@@include[Mermaid Diagram](../snippets/mermaid.md)
+
+is created via
+
+@@snip[Mermaid Source](../snippets/mermaid.md){#mermaid}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,18 @@
+# sbt-paradox-diagrams
+
+A simple paradox plugin, which will draw diagrams from formal definitions.
+
+## Supported Diagram Types
+ - Sequence Diagrams (via https://bramp.github.io/js-sequence-diagrams)
+ - FlowCharts (via http://flowchart.js.org)
+ - Gantt and others (via https://mermaidjs.github.io)
+
+For more information on supported diagrams, visit the listed sites.
+
+@@@ index
+
+* [Setup](setup.md)
+* [Examples](examples.md)
+* [Todo](todo.md)
+
+@@@

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,9 @@
+## Setup
+
+Add the following lines to your `project/plugins.sbt`:
+
+@@@vars
+```scala
+addSbtPlugin("com.wanari" % "sbt-paradox-diagrams" % "$version$")
+```
+@@@

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,4 @@
+## Todo
+
+- <strike>release on maven central</strike>
+- add dot and railroad, idea from: https://github.com/francoislaberge/diagrams

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,12 @@
+resolvers += Opts.resolver.sonatypeSnapshots
+
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.6.5")
+addSbtPlugin("io.github.jonas" % "sbt-paradox-material-theme" % "0.6.0")
+addSbtPlugin("com.drobisch" % "sbt-paradox-diagrams" % "0.0.2-SNAPSHOT")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += Opts.resolver.sonatypeSnapshots
-
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
@@ -9,4 +7,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.6.5")
 addSbtPlugin("io.github.jonas" % "sbt-paradox-material-theme" % "0.6.0")
-addSbtPlugin("com.drobisch" % "sbt-paradox-diagrams" % "0.0.2-SNAPSHOT")
+
+unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "src" / "main" / "scala"

--- a/snippets/flow.md
+++ b/snippets/flow.md
@@ -1,12 +1,6 @@
-@@@ sequence-diagram
-```raw
-Andrew->China: Says Hello
-Note right of China: China thinks about it
-China-->Andrew: How are you?
-Andrew->>China: I am good thanks!
-```
-@@@
+### Flow Chart Diagram
 
+<!-- #flow -->
 @@@ flowchart-diagram
 ```raw
 st=>start: Start:>http://www.google.com[blank]
@@ -25,12 +19,4 @@ para(path1, bottom)->sub1(right)->op1
 para(path2, top)->op1
 ```
 @@@
-
-@@@ mermaid-diagram
-```raw
-graph LR
-  A --- B
-  B-->C[fa:fa-ban forbidden]
-  B-->D(fa:fa-spinner ok);
-```
-@@@
+<!-- #flow -->

--- a/snippets/mermaid.md
+++ b/snippets/mermaid.md
@@ -1,0 +1,12 @@
+### Mermaid Diagram
+
+<!--- #mermaid --->
+@@@ mermaid-diagram
+```raw
+graph LR
+  A --- B
+  B-->C[fa:fa-ban forbidden]
+  B-->D(fa:fa-spinner ok);
+```
+@@@
+<!--- #mermaid --->

--- a/snippets/sequence.md
+++ b/snippets/sequence.md
@@ -1,0 +1,12 @@
+### Sequence Diagram
+
+<!--- #sequence --->
+@@@ sequence-diagram
+```raw
+Andrew->China: Says Hello
+Note right of China: China thinks about it
+China-->Andrew: How are you?
+Andrew->>China: I am good thanks!
+```
+@@@
+<!--- #sequence --->

--- a/src/main/scala/com/wanari/paradox/diagrams/SequenceDiagramDirective.scala
+++ b/src/main/scala/com/wanari/paradox/diagrams/SequenceDiagramDirective.scala
@@ -6,7 +6,7 @@ import com.lightbend.paradox.markdown.ContainerBlockDirective
 import org.pegdown.Printer
 import org.pegdown.ast.{DirectiveNode, Visitor}
 
-class SequenceDiagramDirective extends ContainerBlockDirective("seqence-diagram") {
+class SequenceDiagramDirective extends ContainerBlockDirective("sequence-diagram") {
   override def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
 
     val id = s"diagram-${UUID.randomUUID.toString.take(8)}"

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
#hacktoberfest : this adds the necessary plugins and steps to allow releasing on maven
central, working towards #1 

The release process and the requirements are explained in `RELEASE.md`.

Other changes:
- format README
- add `travis.yml`
- fix the `sequence-diagram` directive name
- add the site plugin and docs that include diagrams

For the last point I pushed a snapshot version of the plugin into maven central snapshots with group id `com.drobisch`, so that it can be used from `plugins.sbt`. This can be replaced once a version with the `com.wanari` id is up.

