### PR TITLE
Updated mermaid-js version (8.8.2)

### DIFF
--- a/src/main/scala/com/wanari/paradox/diagrams/MermaidDiagramDirective.scala
+++ b/src/main/scala/com/wanari/paradox/diagrams/MermaidDiagramDirective.scala
@@ -30,7 +30,7 @@ class MermaidDiagramDirective extends ContainerBlockDirective("mermaid-diagram")
 
   def renderScriptTags(printer: Printer) = {
     printer
-      .print("""<script src="https://unpkg.com/mermaid@8.0.0/dist/mermaid.min.js"></script>""")
+      .print("""<script src="https://unpkg.com/mermaid@8.8.2/dist/mermaid.min.js"></script>""")
       .println
   }
 

--- a/src/sbt-test/diagrams/happy-path/expected/index.html
+++ b/src/sbt-test/diagrams/happy-path/expected/index.html
@@ -38,7 +38,7 @@ para(path2, top)->op1
   diagram.drawSVG("diagram-xxxxxxxx");
 </script>
 
-<script src="https://unpkg.com/mermaid@8.0.0/dist/mermaid.min.js"></script>
+<script src="https://unpkg.com/mermaid@8.8.2/dist/mermaid.min.js"></script>
 
 <script>mermaid.initialize({startOnLoad:true});</script>
 <div class="mermaid" id="diagram-xxxxxxxx">
@@ -46,4 +46,6 @@ para(path2, top)->op1
   A --- B
   B-->C[fa:fa-ban forbidden]
   B-->D(fa:fa-spinner ok);
+  B--->E
 </div>
+

--- a/src/sbt-test/diagrams/happy-path/src/main/paradox/index.md
+++ b/src/sbt-test/diagrams/happy-path/src/main/paradox/index.md
@@ -32,5 +32,7 @@ graph LR
   A --- B
   B-->C[fa:fa-ban forbidden]
   B-->D(fa:fa-spinner ok);
+  B--->E
 ```
 @@@
+


### PR DESCRIPTION
Updated mermaid-js version (8.8.2) to support more functionality in diagrams.  Added test which fails in the browser in the old version.  Resolves #68.

Example output:
> ![Screen Shot 2020-10-13 at 9 59 31 AM](https://user-images.githubusercontent.com/521977/95870712-d05dbb00-0d3a-11eb-97bd-6f5fcd3349ba.png)

Note that the `E` in the last graph now supports extending lines to arbitrary length.